### PR TITLE
bump cordova-support-google-services@~1.4.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
     <framework src="com.android.support:support-v13:$ANDROID_SUPPORT_V13_VERSION"/>
     <framework src="me.leolin:ShortcutBadger:1.1.17@aar"/>
     <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION"/>
-    <dependency id="cordova-support-google-services" version="~1.3.1"/>
+    <dependency id="cordova-support-google-services" version="~1.4.1"/>
     <dependency id="phonegap-plugin-multidex" version="~1.0.0"/>
     <source-file src="src/android/com/adobe/phonegap/push/FCMService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/"/>


### PR DESCRIPTION
Fixes added for
**Failed to install 'phonegap-plugin-push'**
```
CordovaError: Version of installed plugin: "cordova-support-google-services@1.4.1" does not satisfy dependency plugin requirement "cordova-support-google-services@~1.3.1". Try --force to use installed plugin as dependency.
```
